### PR TITLE
Create pull_request_labels.yml

### DIFF
--- a/.github/workflows/pull_request_labels.yml
+++ b/.github/workflows/pull_request_labels.yml
@@ -1,0 +1,15 @@
+name: Pull Request Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 1
+          labels: "patch, minor, major"


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/29402677

### Summary
Required release-related labels on PRs. Requires exactly one semvar label.

### Testing
- [x] confirm the action check fails for this PR
- [x] add a "patch" label here, confirm the check passes now

### Concern
- Not sure if we want to enforce "category" labels like these here https://github.com/werkbot/silverstripe-module-search/blob/master/.github/release-drafter.yml#L5. You could have a mixture of labels like that, so we would need to figure out how the rules should work for those.