### PR TITLE
fix: proper insert and update index columns

### DIFF
--- a/src/SearchableExtension.php
+++ b/src/SearchableExtension.php
@@ -140,7 +140,7 @@ class SearchableExtension extends DataExtension
   {
       $index = TNTSearchHelper::Instance()->getTNTSearchIndex();
       $index->update(
-          $this->owner->ID,
+          ClassInfo::shortName($this->owner->ClassName)."_".$this->owner->ID,
           [
             'ID' => ClassInfo::shortName($this->owner->ClassName)."_".$this->owner->ID,
             'ClassName' => $this->owner->ClassName,

--- a/src/SearchableExtension.php
+++ b/src/SearchableExtension.php
@@ -75,7 +75,7 @@ class SearchableExtension extends DataExtension
   }
   /**
    * getSearchableSummary
-   * Returns the content, to be used in search results
+   * Returns the content to be used in search results
    * Override if Content uses a different variable name
    *
    * @return string
@@ -87,6 +87,20 @@ class SearchableExtension extends DataExtension
       } else {
           return $this->owner->Content;
       }
+  }
+  /**
+   * getSearchableContent
+   * Returns the content to be used when indexing this record
+   * Override if Content uses a different variable name or to include more searchable content:
+   *
+   * Example, the specified column data from all child records will be concatendated to the searchable content:
+   * return $this->Content . implode(',', $this->Children()->column('SearchTerm'));
+   *
+   * @return string
+  **/
+  public function getSearchableContent()
+  {
+    return $this->getSearchableSummary();
   }
   /**
    * getSearchableSummaryColumnName
@@ -113,8 +127,8 @@ class SearchableExtension extends DataExtension
       $index->insert([
         'ID' => ClassInfo::shortName($this->owner->ClassName)."_".$this->owner->ID,
         'ClassName' => $this->owner->ClassName,
-        $this->owner->getSearchableTitleColumnName() => $this->owner->getSearchableTitle(),
-        $this->owner->getSearchableSummaryColumnName() => $this->owner->getSearchableSummary(),
+        'Title' => $this->owner->getSearchableTitle(),
+        'Content' => $this->owner->getSearchableContent(),
       ]);
   }
   /**
@@ -130,8 +144,8 @@ class SearchableExtension extends DataExtension
           [
             'ID' => ClassInfo::shortName($this->owner->ClassName)."_".$this->owner->ID,
             'ClassName' => $this->owner->ClassName,
-            $this->owner->getSearchableTitleColumnName() => $this->owner->getSearchableTitle(),
-            $this->owner->getSearchableSummaryColumnName() => $this->owner->getSearchableSummary(),
+            'Title' => $this->owner->getSearchableTitle(),
+            'Content' => $this->owner->getSearchableContent(),
           ]
       );
   }


### PR DESCRIPTION
### Summary
- Updated `insertIndex` and `updateIndex` to use column names consistent with `getIndexQuery`
- Added separate `getSearchableContent` function for indexing content. This is different from `getSearchableSummary`, as the content returned here will not show in the search result summary.

### Testing Steps
- [x] test with a DataObject that defines a `$SearchableExtension_Summary_ColumnName` that is not "Content"
- [x] update the content in the field that `$SearchableExtension_Summary_ColumnName` describes ("DescriptionSummary" on Products)
- [x] publish the record
- [x] search on the frontend for your updated content
- [x] confirm results show
- [x] define an override for `getSearchableContent` on your DataObject, have it return some other string
- [x] publish the record and search for your `getSearchableContent` string
- [x] confirm the results show good

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "master"
