### PR TITLE
Feature/old query cutoff age config

### DIFF
--- a/docs/en/remove_search_queries_job.md
+++ b/docs/en/remove_search_queries_job.md
@@ -1,0 +1,7 @@
+# Remove Search Queries Job
+By default, the RemoveSearchQueriesJob removes SearchQueries that are more than a year old. This job also queues itself for tomorrow by default. This behavior can be altered in the RemoveSearchQueriesJob configuration.
+```yml
+Werkbot\Search\RemoveSearchQueriesJob:
+  max_age: '30 days'
+  queue_next_run: 'next week'
+```


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/app/tasks/32317531

### Summary
Added configuration option to control search queries' max_age and next queued job date

### Testing Steps
- [x] test with any site that uses the search module (ben franklin is my test case)
- [x] create search queries, manually set the dates on some of these to over a year old
- [x] create a RemoveSearchQueriesJob instance in the jobs admin and execute it
- [x] confirm search queries that are older than a year are removed by default, and the next job is queued for tomorrow
- [x] confirm the configuration options work (refer to the added documentation)

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "master"
