### PR TITLE
fix: added check for search key, updated workflow files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,4 @@
 ### Git Flow
 - **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
 - "Squash and merge" is good on "feature/\*" into "develop"
-- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "master"
+- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"

--- a/.github/workflows/pull_request_labels.yml
+++ b/.github/workflows/pull_request_labels.yml
@@ -8,8 +8,9 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v2
+      - uses: mheap/github-action-required-labels@v3
         with:
           mode: exactly
           count: 1
-          labels: "patch, minor, major"
+          labels: "patch, minor, major, automerge"
+

--- a/src/SearchControllerExtension.php
+++ b/src/SearchControllerExtension.php
@@ -75,7 +75,7 @@ class SearchControllerExtension extends DataExtension
       $Results = new ArrayList();
       $ErrorMessge = "";
 
-      if ($searchdata['Search']) {
+      if (isset($searchdata['Search'])) {
           try {
               $tnt = TNTSearchHelper::Instance()->getTNTSearch();
               $tnt->selectIndex('site.index');


### PR DESCRIPTION
https://werkbot.sentry.io/issues/4289566830/events/1492c5c3d279427c8be72f5b05a46334/?project=5403165

### Summary
Added check for a Search key

### Testing Steps
- [x] go to /home/SiteSearchForm (get request)
- [x] confirm no error shows

### Concern
- I noticed that issues in Sentry are grouped by the error type and not by the site or specific issue. So there are many different issues listed as "Events" for "ErrorException" https://werkbot.sentry.io/issues/4289566830/events/?project=5403165&referrer=issue-stream&stream_index=0

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "master"
