### PR TITLE
fix: replaced requireDefaultRecords with DatabaseAdminExtension onAft…

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,7 @@
+---
+Name: Search Module dev/build
+---
+SilverStripe\ORM\DatabaseAdmin:
+  extensions:
+    - Werkbot\Search\DatabaseAdminExtension
+

--- a/src/DatabaseAdminExtension.php
+++ b/src/DatabaseAdminExtension.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Werkbot\Search;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\ORM\DataExtension;
+
+class DatabaseAdminExtension extends DataExtension
+{
+  public function onAfterBuild()
+  {
+    (new SearchIndex())->run(Controller::curr()->getRequest());
+  }
+}
+

--- a/src/SearchableExtension.php
+++ b/src/SearchableExtension.php
@@ -1,12 +1,11 @@
 <?php
-/**/
+
 namespace Werkbot\Search;
-/**/
-use SilverStripe\ORM\DB;
+
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\Versioned\Versioned;
-/**/
+
 class SearchableExtension extends DataExtension
 {
   /*
@@ -15,7 +14,7 @@ class SearchableExtension extends DataExtension
   */
   public $SearchableExtension_Title_ColumnName = "Title";
   public $SearchableExtension_Summary_ColumnName = "Content";
-  /**/
+
   private static $casting = [
     "getSearchableTitle" => "Text",
     "getSearchableSummary" => 'HTMLText',
@@ -223,23 +222,5 @@ class SearchableExtension extends DataExtension
   {
       $this->owner->deleteIndex();
   }
-  /**
-   * requireDefaultRecords
-   * Runs the index on a dev/build
-  **/
-  public function requireDefaultRecords()
-  {
-      parent::requireDefaultRecords();
-
-      if (!file_exists(dirname(__DIR__, 4).'/search')) {
-          mkdir(dirname(__DIR__, 4).'/search');
-          echo "Created search folder<br /><br />";
-      }
-      $indexer = TNTSearchHelper::Instance()->getTNTSearchIndex(true);
-      if ($query = $this->owner->getIndexQuery()) {
-          $indexer->query($query);
-          $indexer->run();
-          DB::alteration_message('Indexing...'.$this->owner->ClassName, 'created');
-      }
-  }
 }
+

--- a/src/Tasks/SearchIndex.php
+++ b/src/Tasks/SearchIndex.php
@@ -1,34 +1,34 @@
 <?php
-/**/
+
 namespace Werkbot\Search;
-/**/
-use SilverStripe\Dev\BuildTask;
+
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\ORM\DB;
 use Werkbot\Search\TNTSearchHelper;
-/**/
+
 class SearchIndex extends BuildTask
 {
-  /**/
   protected $title = "Search Index";
   protected $description = "";
   protected $enabled = true;
-  /**/
+
   public function run($request)
   {
-      if (!file_exists(dirname(__DIR__, 5).'/search')) {
-          mkdir(dirname(__DIR__, 5).'/search');
-          echo "Created search folder<br /><br />";
+    if (!file_exists(dirname(__DIR__, 5) . '/search')) {
+      mkdir(dirname(__DIR__, 5) . '/search');
+      echo "Created search folder<br /><br />";
+    }
+    $indexer = TNTSearchHelper::Instance()->getTNTSearchIndex(true);
+    $classes = ClassInfo::classesWithExtension(SearchableExtension::class);
+    foreach ($classes as $title => $className) {
+      $searchableClass = singleton($className);
+      if ($query = $searchableClass->getIndexQuery()) {
+        $indexer->query($query);
+        $indexer->run();
+        DB::alteration_message('Indexing...' . $className, 'created');
       }
-      $indexer = TNTSearchHelper::Instance()->getTNTSearchIndex(true);
-      $classes = ClassInfo::classesWithExtension(SearchableExtension::class);
-      foreach ($classes as $Title => $ClassName) {
-          $searchableClass = singleton($ClassName);
-          if ($query = $searchableClass->getIndexQuery()) {
-              echo "Indexing...$ClassName<br />";
-              $indexer->query($query);
-              $indexer->run();
-              echo "<br /><br />";
-          }
-      }
+    }
   }
 }
+


### PR DESCRIPTION
…erBuild

https://github.com/werkbot/fairview-evergreen-nursery/pull/40#issuecomment-1866695426

### Summary
Replaces requireDefaultRecords with DatabaseAdminExtension onAfterBuild.
Fixes dev/build search index issue.

### Testing Steps
- [x] dev/build
- [x] confirm all searchable data objects are searchable
- [x] (optional) test the search index task (uses `DB::alteration_message` instead of echos now)

### Issues/Concerns
- `$indexer->run()` replaces all records in the index file. `requireDefaultRecords` would call it multiple times, erasing any previously indexed data object. Only my pages were searchable.

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
