### PR TITLE
Updated SQL for mysql 8

### DIFF
--- a/src/SearchQueries/CustomeSideReport_SearchQuery.php
+++ b/src/SearchQueries/CustomeSideReport_SearchQuery.php
@@ -15,19 +15,19 @@ class CustomSideReport_SearchQuery extends Report
   {
     return 'Search Query Report';
   }
-  
+
   public function description()
   {
     $desc = 'Shows search queries';
 
     return $desc;
   }
-  
+
   public function sort()
   {
     return 1;
   }
-  
+
   public function records($params = null)
   {
     if ($params){
@@ -40,13 +40,15 @@ class CustomSideReport_SearchQuery extends Report
 
     $records = new ArrayList();
     $sql = "
-      SELECT
-        Created, Query, COUNT(*) AS QueryCount
+       SELECT
+        Max(Created) as Created, Query, COUNT(*) AS QueryCount
       FROM
         SearchQuery
       WHERE
         Created BETWEEN '".$StartDate."' AND '".$EndDate."'
       GROUP BY
+        Query
+      ORDER BY
         Query ASC
     ";
     $results = DB::query($sql);
@@ -63,13 +65,13 @@ class CustomSideReport_SearchQuery extends Report
 
     return $records;
   }
-  
+
   public function sourceRecords($params = null)
   {
     $params = ((isset($_REQUEST['filters'])) ? $_REQUEST['filters'] : null);
     return $this->records($params);
   }
-  
+
   public function columns()
   {
     $fields = [
@@ -86,8 +88,8 @@ class CustomSideReport_SearchQuery extends Report
 
     return $fields;
   }
-  
-  public function parameterFields() 
+
+  public function parameterFields()
   {
     $today = date('Y-m-d');
 


### PR DESCRIPTION
- ASC after the group by throws an exception in mysql 8

### Summary
>Fixed exception in mysql8 for group by with the ASC following

### Testing Steps
- [x] Test with a site with the search
- [x] Verify there is no error on loading of the reports area
- [x] Verify the report is still correct for the search queries

### Issues/Concerns
- This came up on the Reed site, looked good locally so might just need to verify the reports look the same when loading them compared to a live site report

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
