### PR TITLE
feat: added extension point to getIndexQuery

### DIFF
--- a/.github/workflows/publish_release_draft.yml
+++ b/.github/workflows/publish_release_draft.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Create Pull Request
         id: create_pr
         if: steps.is_support_branch.outputs.filtered_branch_name == ''
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           title: Auto-Update CHANGELOG.md
           commit-message: Updated CHANGELOG.md

--- a/src/SearchableExtension.php
+++ b/src/SearchableExtension.php
@@ -135,7 +135,9 @@ class SearchableExtension extends DataExtension
    **/
   public function getIndexQuery()
   {
-    return false;
+    $query = '';
+    $this->owner->extend('updateIndexQuery', $query);
+    return $query;
   }
   /**
    * getSearchableID


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/app/tasks/39565673

### Summary
added extension point to getIndexQuery. Allows index query to be added by dataextensions

### Testing Steps
- [x] test with flexcut https://github.com/werkbot/flexcut/pull/255
- [x] confirm the product index query (added in a data extension) works

### Issues/Concerns
- If the base class defines `getIndexQuery` (like blog Articles in the case of flexcut), this won't be used. Feel free to double check this by extending articles.
- We will likely want to carry this up to the main branch

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
