### PR TITLE
fix: search relevance by using one big query (properly sets total_doc…

### DIFF
--- a/sass/components/_search-results.scss
+++ b/sass/components/_search-results.scss
@@ -1,19 +1,21 @@
-.search-query{
+.search-query {
   background: #efefef;
   padding: 20px;
   margin-bottom: 20px;
   border: solid 1px #cccccc;
-  h2{
+  h2 {
     font-size: 1.5em;
     line-height: 1;
     margin: 0;
   }
 }
-.search-result{
+
+.search-result {
   margin-bottom: 20px;
   padding: 10px 0;
   border-bottom: solid 1px #cccccc;
-  mark{
+  mark {
     background: rgba(255,255,0,0.25);
+    color: #000;
   }
 }

--- a/src/Helpers/TNTSearchHelper.php
+++ b/src/Helpers/TNTSearchHelper.php
@@ -39,6 +39,7 @@ class TNTSearchHelper
         'storage'   => dirname(__DIR__, 5).'/search',
         'stemmer'   => \TeamTNT\TNTSearch\Stemmer\PorterStemmer::class
       ]);
+      $tnt->engine->steps = 99999;
       return $tnt;
   }
 

--- a/src/SearchableExtension.php
+++ b/src/SearchableExtension.php
@@ -14,6 +14,7 @@ use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\DB;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
@@ -248,24 +249,45 @@ class SearchableExtension extends DataExtension
   }
 
   /**
+   * Get the ID used in the search index
+   * @return string
+   */
+  public function getIndexID()
+  {
+    return ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID;
+  }
+
+  /**
+   * Get the search index document for this records
+   * This is used when inserting and updating the search index
+   * @return array
+   */
+  public function getIndexDocument()
+  {
+    $id = $this->getIndexID();
+    $classQuery = rtrim($this->owner->getIndexQuery(), ';');
+    $query = <<<SQL
+      SELECT * FROM (
+        $classQuery
+      ) AS indexquery
+        WHERE
+          ID = '$id'
+    SQL;
+    $query = str_replace('"', "'", $query);
+    return DB::query($query)->record();
+  }
+
+  /**
    * insertIndex
    *
    * @return void
    **/
   public function insertIndex()
   {
-    $content = $this->owner->getSearchableContent();
-    if (!$content) {
-      return;
-    }
-
+    $document = $this->getIndexDocument();
+    if (!$document) return;
     $index = TNTSearchHelper::Instance()->getTNTSearchIndex();
-    $index->insert([
-      'ID' => ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID,
-      'ClassName' => $this->owner->ClassName,
-      'Title' => $this->owner->getSearchableTitle(),
-      'Content' => $content,
-    ]);
+    $index->insert($document);
   }
 
   /**
@@ -275,21 +297,11 @@ class SearchableExtension extends DataExtension
    **/
   public function updateIndex()
   {
-    $content = $this->owner->getSearchableContent();
-    if (!$content) {
-      return;
-    }
-
+    $document = $this->getIndexDocument();
+    if (!$document) return;
+    $id = $this->getIndexID();
     $index = TNTSearchHelper::Instance()->getTNTSearchIndex();
-    $index->update(
-      ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID,
-      [
-        'ID' => ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID,
-        'ClassName' => $this->owner->ClassName,
-        'Title' => $this->owner->getSearchableTitle(),
-        'Content' => $content,
-      ]
-    );
+    $index->update($id, $document);
   }
 
   /**
@@ -300,7 +312,7 @@ class SearchableExtension extends DataExtension
   public function deleteIndex()
   {
     $index = TNTSearchHelper::Instance()->getTNTSearchIndex();
-    $index->delete(ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID);
+    $index->delete($this->getIndexID());
   }
 
   /**

--- a/src/Tasks/SearchIndex.php
+++ b/src/Tasks/SearchIndex.php
@@ -11,7 +11,7 @@ use Werkbot\Search\SearchableExtension;
 class SearchIndex extends BuildTask
 {
   protected $title = "Search Index";
-  protected $description = "";
+  protected $description = "Index DataObjects with SearchableExtension";
   protected $enabled = true;
 
   public function run($request)
@@ -20,15 +20,29 @@ class SearchIndex extends BuildTask
       mkdir(dirname(__DIR__, 5) . '/search');
       echo "Created search folder<br /><br />";
     }
+
     $indexer = TNTSearchHelper::Instance()->getTNTSearchIndex(true);
     $classes = ClassInfo::classesWithExtension(SearchableExtension::class);
+
+    $query = '';
     foreach ($classes as $title => $className) {
       $searchableClass = singleton($className);
-      if ($query = $searchableClass->getIndexQuery()) {
+      if ($classQuery = $searchableClass->getIndexQuery()) {
+        // Remove semi-colon if it exists
+        $classQuery = rtrim($classQuery, ';');
+
+        $query .= $classQuery . ' UNION ALL ';
+
         DB::alteration_message('Indexing...' . $className, 'created');
-        $indexer->query($query);
-        $indexer->run();
       }
     }
+    $query = str_replace('"', "'", $query);
+
+    // Remove last " UNION ALL "
+    $query = substr($query, 0, -11);
+
+    $indexer->query($query);
+    $indexer->run();
   }
+
 }


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/app/tasks/39608949
https://werkbotstudios.teamwork.com/app/tasks/39602444

### Summary
- Fix search relevance by running `run()` once, with one large query. This prevents the [total_documents from being set to 0, which messes with the docScores](https://github.com/teamtnt/tntsearch/blob/7488ca8c856919b7b65ceb4162964a5189dd5bb2/src/TNTSearch.php#L119-L140).
- Updated `insertIndex` and `updateIndex` to use the same searchable content as the initial index query. Keeps the searchable content consistent when publishing/saving a searchable object
- Added description to search index task
- Increased the steps of the search indexer engine, that way all rows are processed
- Set mark text color to black, that way keywords in the results are visible.

### Testing Steps
- [x] test with any compatible site
- [x] confirm all rows are processed
- [x] confirm the search relevance is improved
- [x] confirm the updated and new searchable records work well after saving/publishing

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
