### PR TITLE
Release/3.1.0/indexing changes

### DIFF
--- a/.github/workflows/publish_release_draft.yml
+++ b/.github/workflows/publish_release_draft.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Create Pull Request
         id: create_pr
         if: steps.is_support_branch.outputs.filtered_branch_name == ''
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           title: Auto-Update CHANGELOG.md
           commit-message: Updated CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -31,21 +31,35 @@ The `Page::class` will need to have a function `getIndexQuery` defined. Here is 
  */
 public function getIndexQuery()
 {
-  return "SELECT
-      concat(\"Page_\", SiteTree.ID) AS ID,
-      SiteTree.ClassName,
-      SiteTree.Title,
-      SiteTree.Content
+  $class = get_class($this);
+  $class = str_replace('\\', '\\\\', $class);
+
+  /*
+    Alternatively, just use the short class name of the current file
+    Example: "Page"
+  */
+  $indexQueryDeclaringClassShortname = $this->owner->getIndexQueryDeclaringClassShortname();
+
+  return <<<SQL
+    SELECT
+      concat("{$indexQueryDeclaringClassShortname}_", SiteTree_Live.ID) AS ID,
+      SiteTree_Live.ClassName,
+      SiteTree_Live.Title,
+      SiteTree_Live.Content
     FROM
       Page
     LEFT JOIN
-      SiteTree
+      SiteTree_Live
     ON
-      SiteTree.ID = Page.ID
+      SiteTree_Live.ID = Page.ID
     WHERE
-      SiteTree.ShowInSearch = '1'"
+      SiteTree_Live.ShowInSearch = '1'
     AND
-      SiteTree.Content IS NOT NULL;
+      -- Keeps subclasses from re-indexing duplicates
+      SiteTree_Live.ClassName = '$class'
+    AND
+      SiteTree_Live.Content IS NOT NULL
+  SQL;
 }
 ```
 This is a simple query that is used by the indexer to index your content.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,5 +1,4 @@
 ## Usage
-
 ### DataObject Setup
 Just add the extension:
 ```
@@ -7,25 +6,57 @@ DataObject::add_extension(\Werkbot\Search\SearchableExtension::class);
 ```
 
 Then define `getIndexQuery` function on the DataObject:
-```
-public function getIndexQuery(){
-  return "SELECT
-      concat(\"CLASSNAME_\", ID) AS ID,
+```php
+public function getIndexQuery()
+{
+  return <<<SQL
+    SELECT
+      concat("CLASSNAME_", ID) AS ID,
       ClassName,
       Title,
       Content
     FROM
-      CLASSNAME";
+      CLASSNAME
+  SQL;
 }
 ```
 
 In the query, the classname of the dataobject is added to the id, like so: `concat(\"CLASSNAME_\", ID) AS ID`
 So it's the Classname of the DataObject, followed by an underscore, then the ID selector. This is used by the search function (`function SiteSearchFormResults`), it allows us to lookup the objects correctly.
 
-The object will also need to have a `Link` function defined that returns a link. This is used for the search results to link the result to a corresonding page. Here is an example of a dataobject that has a `has_one` relationship with `Page::class`:
+If more searchable content is needed, you can use `CONCAT_WS` to concatenate multiple fields together, for example:
+```sql
+SELECT
+  concat("CLASSNAME_", ID) AS ID,
+  ClassName,
+  Title,
+  CONCAT_WS(' ', Content, ExtraContent) AS Content
 ```
+In this example, the `Content` and `ExtraContent` fields are concatenated together with a space in between. Be sure to alias the concatenated fields as `Content`.
+
+If you would like to add or override the index query with a DataExtension, you can define the `updateIndexQuery` function on the extension, for example:
+```php
+public function updateIndexQuery(&$query)
+{
+  $query = <<<SQL
+    SELECT
+      concat("CLASSNAME_", ID) AS ID,
+      ClassName,
+      Title,
+      Content
+    FROM
+      CLASSNAME
+  SQL;
+}
+```
+
+In this example, the `updateIndexQuery` function is defined on a DataExtension. The function takes the original query reference as an argument, and redefines it.
+
+The object will also need to have a `Link` function defined that returns a link. This is used for the search results to link the result to a corresonding page. Here is an example of a dataobject that has a `has_one` relationship with `Page::class`:
+```php
 /* This returns a link to the Parent Page */
-public function Link(){
+public function Link()
+{
   return $this->Page()->Link();
 }
 ```

--- a/docs/en/fluent.md
+++ b/docs/en/fluent.md
@@ -54,8 +54,7 @@ public function getIndexQuery()
           ' ',
           SiteTree_Localised_Live.Title,
           SiteTree_Localised_Live.MetaDescription,
-          Page_Localised_Live.Desc,
-          Page_Localised_Live.ContentColumnTwo,
+          Page_Localised_Live.TitleContent,
           REGEXP_REPLACE(SiteTree_Localised_Live.Content, '<[^>]*>+', ''),
           REGEXP_REPLACE(GROUP_CONCAT(ContentLayoutHtml_Localised_Live.Content), '<[^>]*>+', '')
         ) AS Content

--- a/docs/en/fluent.md
+++ b/docs/en/fluent.md
@@ -1,0 +1,102 @@
+# Using with the Fluent Module
+## Separate Search Indexes for Each Language
+When using the fluent module for site translations, it is often desireable to have separate search indexes for each language.
+```php
+<?php
+
+use SilverStripe\ORM\DataExtension;
+use TractorCow\Fluent\State\FluentState;
+
+class TNTSearchHelperExtension extends DataExtension
+{
+  public function updateSearchIndexName(&$name)
+  {
+    $locale = FluentState::singleton()->withState(function (FluentState $state) {
+      return $state->getLocale();
+    });
+
+    $name = $locale . '-site.index';
+  }
+}
+```
+
+```yml
+Werkbot\Search\Helpers\TNTSearchHelper:
+  extensions:
+    - TNTSearchHelperExtension
+```
+
+This will create a separate index for each locale, with the locale code as a prefix. For example, if you have two locales "en" and "fr", you will have two indexes: "en-site.index" and "fr-site.index".
+
+You can produce each file by switching the locale in the CMS and running the search index dev task.
+```
+php vendor/silverstripe/framework/cli-script.php /dev/tasks/Werkbot-Search-Tasks-SearchIndex
+```
+## Localised Index Queries
+When you have separate indexes for each language, you will also need to modify your search index queries to use the correct locale content.
+```php
+public function getIndexQuery()
+{
+  $class = get_class($this);
+  $class = str_replace('\\', '\\\\', $class);
+
+  $locale = FluentState::singleton()->withState(function (FluentState $state) {
+    return $state->getLocale();
+  });
+
+  return <<<SQL
+    SELECT * FROM (
+      SELECT
+        concat("Page_", SiteTree_Live.ID) AS ID,
+        SiteTree_Live.ClassName,
+        SiteTree_Localised_Live.Title,
+        CONCAT_WS(
+          ' ',
+          SiteTree_Localised_Live.Title,
+          SiteTree_Localised_Live.MetaDescription,
+          Page_Localised_Live.Desc,
+          Page_Localised_Live.ContentColumnTwo,
+          REGEXP_REPLACE(SiteTree_Localised_Live.Content, '<[^>]*>+', ''),
+          REGEXP_REPLACE(GROUP_CONCAT(ContentLayoutHtml_Localised_Live.Content), '<[^>]*>+', '')
+        ) AS Content
+      FROM
+        SiteTree_Live
+      LEFT JOIN
+        SiteTree_Localised_Live
+      ON
+        SiteTree_Localised_Live.RecordID = SiteTree_Live.ID
+      LEFT JOIN
+        Page_Localised_Live
+      ON
+        Page_Localised_Live.RecordID = SiteTree_Live.ID
+      LEFT JOIN
+        ContentLayout_Live
+      ON
+        ContentLayout_Live.PageID = Page_Localised_Live.RecordID
+      LEFT JOIN
+        ContentLayoutHtml_Localised_Live
+      ON
+        ContentLayoutHtml_Localised_Live.RecordID = ContentLayout_Live.ID
+      WHERE
+        SiteTree_Live.ShowInSearch = '1'
+      AND
+        SiteTree_Live.ClassName = '$class'
+      AND
+        SiteTree_Localised_Live.Locale = '$locale'
+      AND
+        Page_Localised_Live.Locale = '$locale'
+      AND (
+        ContentLayoutHtml_Localised_Live.Locale = '$locale'
+        OR
+        -- If no ContentLayoutHtmls exist on the Page we still index it
+        ContentLayoutHtml_Localised_Live.Locale IS NULL
+      )
+      GROUP BY
+        Page_Localised_Live.RecordID
+    ) AS BASE
+    WHERE
+      Content != '';
+  SQL;
+}
+```
+

--- a/sass/components/_search-results.scss
+++ b/sass/components/_search-results.scss
@@ -1,19 +1,21 @@
-.search-query{
+.search-query {
   background: #efefef;
   padding: 20px;
   margin-bottom: 20px;
   border: solid 1px #cccccc;
-  h2{
+  h2 {
     font-size: 1.5em;
     line-height: 1;
     margin: 0;
   }
 }
-.search-result{
+
+.search-result {
   margin-bottom: 20px;
   padding: 10px 0;
   border-bottom: solid 1px #cccccc;
-  mark{
+  mark {
     background: rgba(255,255,0,0.25);
+    color: #000;
   }
 }

--- a/src/Helpers/TNTSearchHelper.php
+++ b/src/Helpers/TNTSearchHelper.php
@@ -39,6 +39,7 @@ class TNTSearchHelper
         'storage'   => dirname(__DIR__, 5).'/search',
         'stemmer'   => \TeamTNT\TNTSearch\Stemmer\PorterStemmer::class
       ]);
+      $tnt->engine->steps = 99999;
       return $tnt;
   }
 

--- a/src/SearchableExtension.php
+++ b/src/SearchableExtension.php
@@ -144,6 +144,7 @@ class SearchableExtension extends DataExtension
     $this->owner->extend('updateIndexQuery', $query);
     return $query;
   }
+
   /**
    * getSearchableID
    * Returns the ID to be used in search results, for objects that are apart of a page this can be
@@ -153,7 +154,7 @@ class SearchableExtension extends DataExtension
    */
   public function getSearchableID()
   {
-    return $this->owner->ClassName . "_" . $this->owner->ID;
+    return $this->getIndexQueryDeclaringClassShortname() . "_" . $this->owner->ID;
   }
 
   /**
@@ -249,12 +250,24 @@ class SearchableExtension extends DataExtension
   }
 
   /**
-   * Get the ID used in the search index
+   * Get the class that defines the getIndexQuery method
+   * This is used to determine the class name prefix for the ID field in the search index
    * @return string
    */
-  public function getIndexID()
+  public function getIndexQueryDeclaringClass()
   {
-    return ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID;
+    $definesGetIndexQuery = new \ReflectionMethod($this->owner, 'getIndexQuery');
+    return $definesGetIndexQuery->getDeclaringClass()->getName();
+  }
+
+  /**
+   * Get the short name of the class that defines the getIndexQuery method
+   * This is used to determine the class name prefix for the ID field in the search index
+   * @return string
+   */
+  public function getIndexQueryDeclaringClassShortname()
+  {
+    return ClassInfo::shortName($this->owner->getIndexQueryDeclaringClass());
   }
 
   /**
@@ -264,7 +277,7 @@ class SearchableExtension extends DataExtension
    */
   public function getIndexDocument()
   {
-    $id = $this->getIndexID();
+    $id = $this->getSearchableID();
     $classQuery = rtrim($this->owner->getIndexQuery(), ';');
     $query = <<<SQL
       SELECT * FROM (
@@ -299,7 +312,7 @@ class SearchableExtension extends DataExtension
   {
     $document = $this->getIndexDocument();
     if (!$document) return;
-    $id = $this->getIndexID();
+    $id = $this->getSearchableID();
     $index = TNTSearchHelper::Instance()->getTNTSearchIndex();
     $index->update($id, $document);
   }
@@ -312,7 +325,7 @@ class SearchableExtension extends DataExtension
   public function deleteIndex()
   {
     $index = TNTSearchHelper::Instance()->getTNTSearchIndex();
-    $index->delete($this->getIndexID());
+    $index->delete($this->getSearchableID());
   }
 
   /**

--- a/src/SearchableExtension.php
+++ b/src/SearchableExtension.php
@@ -14,6 +14,7 @@ use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\DB;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
@@ -248,24 +249,45 @@ class SearchableExtension extends DataExtension
   }
 
   /**
+   * Get the ID used in the search index
+   * @return string
+   */
+  public function getIndexID()
+  {
+    return ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID;
+  }
+
+  /**
+   * Get the search index document for this records
+   * This is used when inserting and updating the search index
+   * @return array
+   */
+  public function getIndexDocument()
+  {
+    $id = $this->getIndexID();
+    $classQuery = rtrim($this->owner->getIndexQuery(), ';');
+    $query = <<<SQL
+      SELECT * FROM (
+        $classQuery
+      ) AS indexquery
+        WHERE
+          ID = '$id'
+    SQL;
+    $query = str_replace('"', "'", $query);
+    return DB::query($query)->record();
+  }
+
+  /**
    * insertIndex
    *
    * @return void
    **/
   public function insertIndex()
   {
-    $content = $this->owner->getSearchableContent();
-    if (!$content) {
-      return;
-    }
-
+    $document = $this->getIndexDocument();
+    if (!$document) return;
     $index = TNTSearchHelper::Instance()->getTNTSearchIndex();
-    $index->insert([
-      'ID' => ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID,
-      'ClassName' => $this->owner->ClassName,
-      'Title' => $this->owner->getSearchableTitle(),
-      'Content' => $content,
-    ]);
+    $index->insert($document);
   }
 
   /**
@@ -275,21 +297,11 @@ class SearchableExtension extends DataExtension
    **/
   public function updateIndex()
   {
-    $content = $this->owner->getSearchableContent();
-    if (!$content) {
-      return;
-    }
-
+    $document = $this->getIndexDocument();
+    if (!$document) return;
+    $id = $this->getIndexID();
     $index = TNTSearchHelper::Instance()->getTNTSearchIndex();
-    $index->update(
-      ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID,
-      [
-        'ID' => ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID,
-        'ClassName' => $this->owner->ClassName,
-        'Title' => $this->owner->getSearchableTitle(),
-        'Content' => $content,
-      ]
-    );
+    $index->update($id, $document);
   }
 
   /**
@@ -300,7 +312,7 @@ class SearchableExtension extends DataExtension
   public function deleteIndex()
   {
     $index = TNTSearchHelper::Instance()->getTNTSearchIndex();
-    $index->delete(ClassInfo::shortName($this->owner->ClassName) . "_" . $this->owner->ID);
+    $index->delete($this->getIndexID());
   }
 
   /**

--- a/src/SearchableExtension.php
+++ b/src/SearchableExtension.php
@@ -135,7 +135,9 @@ class SearchableExtension extends DataExtension
    **/
   public function getIndexQuery()
   {
-    return false;
+    $query = '';
+    $this->owner->extend('updateIndexQuery', $query);
+    return $query;
   }
   /**
    * getSearchableID

--- a/src/Tasks/SearchIndex.php
+++ b/src/Tasks/SearchIndex.php
@@ -11,7 +11,7 @@ use Werkbot\Search\SearchableExtension;
 class SearchIndex extends BuildTask
 {
   protected $title = "Search Index";
-  protected $description = "";
+  protected $description = "Index DataObjects with SearchableExtension";
   protected $enabled = true;
 
   public function run($request)
@@ -20,15 +20,29 @@ class SearchIndex extends BuildTask
       mkdir(dirname(__DIR__, 5) . '/search');
       echo "Created search folder<br /><br />";
     }
+
     $indexer = TNTSearchHelper::Instance()->getTNTSearchIndex(true);
     $classes = ClassInfo::classesWithExtension(SearchableExtension::class);
+
+    $query = '';
     foreach ($classes as $title => $className) {
       $searchableClass = singleton($className);
-      if ($query = $searchableClass->getIndexQuery()) {
+      if ($classQuery = $searchableClass->getIndexQuery()) {
+        // Remove semi-colon if it exists
+        $classQuery = rtrim($classQuery, ';');
+
+        $query .= $classQuery . ' UNION ALL ';
+
         DB::alteration_message('Indexing...' . $className, 'created');
-        $indexer->query($query);
-        $indexer->run();
       }
     }
+    $query = str_replace('"', "'", $query);
+
+    // Remove last " UNION ALL "
+    $query = substr($query, 0, -11);
+
+    $indexer->query($query);
+    $indexer->run();
   }
+
 }


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/app/tasks/39621613

### Summary
Release PR for
- fixed search index relevance
- consistent indexes when updating/inserting after writing/publishing
- Dev task description
- Increased indexer step count
- Highlighted results text color
- Updated `getSearchableID` to use the class/subclass that defines `getIndexQuery`
- Documentation
  - Updated `getIndexQuery` example to use the class that defines `getIndexQuery` (used by `getSearchableID`, when writing/publishing)
  - Mentioned use of `updateIndexQuery` in DataExtensions
  - Included basic fluent setup documentation

### Testing Steps
- [x] (optional) test again with reed or moh
- [ ] see updated documentation
  - [ ] confirm the updated documentation makes sense and looks good
  - [ ] (optional) update your page/dataobject index queries, confirm everything works as expected

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
