### PR TITLE
fix: index debug mode, check for updateIndexQuery in dataextensions

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -67,6 +67,8 @@ The index is stored in the root directory of your project: `/search/site.index`
 
 The index is initially created on a `dev/build`. Additional `dev/build`'s will update the index for all objects with the extension.
 
+Alternatively, you can run `dev/tasks/Werkbot-Search-Tasks-SearchIndex` to build the index. Here, you can add `?debug` to the task URL to catch any potentially invalid index queries.
+
 For all objects that have the extension applied, the index is updated on creation, edits/updates and delete/removals. So the index is always up to date.
 
 

--- a/src/SearchableExtension.php
+++ b/src/SearchableExtension.php
@@ -3,6 +3,7 @@
 namespace Werkbot\Search;
 
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
@@ -256,8 +257,28 @@ class SearchableExtension extends DataExtension
    */
   public function getIndexQueryDeclaringClass()
   {
-    $definesGetIndexQuery = new \ReflectionMethod($this->owner, 'getIndexQuery');
-    return $definesGetIndexQuery->getDeclaringClass()->getName();
+    try {
+      $definesGetIndexQuery = new \ReflectionMethod($this->owner, 'getIndexQuery');
+      return $definesGetIndexQuery->getDeclaringClass()->getName();
+    } catch (\ReflectionException $e) {
+      // If the base class does not define getIndexQuery, it may be defined in an Extension
+      return $this->getUpdateQueryDeclaringClass($this->owner->ClassName);
+    }
+  }
+
+  /**
+   * Recursively check extensions for the class with the extension that defines the updateIndexQuery method
+   * @param string $class - The DataOject class name to check for the method
+   * @return string|null - The class name with an extension that defines the updateIndexQuery method
+   */
+  public function getUpdateQueryDeclaringClass($class)
+  {
+    if (!$class) return;
+    $extensions = Config::inst()->get($class, 'extensions', Config::UNINHERITED) ?: [];
+    foreach (array_reverse($extensions) as $extensionClass) {
+      if (method_exists($extensionClass, 'updateIndexQuery')) return $class;
+    }
+    return $this->getUpdateQueryDeclaringClass(get_parent_class($class));
   }
 
   /**
@@ -279,6 +300,7 @@ class SearchableExtension extends DataExtension
   {
     $id = $this->getSearchableID();
     $classQuery = rtrim($this->owner->getIndexQuery(), ';');
+    $classQuery = str_replace('"', "'", $classQuery);
     $query = <<<SQL
       SELECT * FROM (
         $classQuery
@@ -286,7 +308,6 @@ class SearchableExtension extends DataExtension
         WHERE
           ID = '$id'
     SQL;
-    $query = str_replace('"', "'", $query);
     return DB::query($query)->record();
   }
 

--- a/src/Tasks/SearchIndex.php
+++ b/src/Tasks/SearchIndex.php
@@ -36,7 +36,12 @@ class SearchIndex extends BuildTask
 
         if ($debugMode) {
           // Ensure this query is valid by running it before adding it to the indexer
-          DB::query($classQuery);
+          try {
+            DB::query($classQuery);
+          } catch (\SilverStripe\ORM\Connect\DatabaseException $e) {
+            echo "<br>Error in query for class $className: " . $e->getMessage() . '<br>';
+            return;
+          }
         }
 
         $query .= $classQuery . ' UNION ALL ';

--- a/src/Tasks/SearchIndex.php
+++ b/src/Tasks/SearchIndex.php
@@ -21,6 +21,8 @@ class SearchIndex extends BuildTask
       echo "Created search folder<br /><br />";
     }
 
+    $debugMode = $request->getVar('debug') !== null;
+
     $indexer = TNTSearchHelper::Instance()->getTNTSearchIndex(true);
     $classes = ClassInfo::classesWithExtension(SearchableExtension::class);
 
@@ -30,6 +32,12 @@ class SearchIndex extends BuildTask
       if ($classQuery = $searchableClass->getIndexQuery()) {
         // Remove semi-colon if it exists
         $classQuery = rtrim($classQuery, ';');
+        $classQuery = str_replace('"', "'", $classQuery);
+
+        if ($debugMode) {
+          // Ensure this query is valid by running it before adding it to the indexer
+          DB::query($classQuery);
+        }
 
         $query .= $classQuery . ' UNION ALL ';
 


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/app/tasks/39646343

### Summary
- index debug mode
- check for updateIndexQuery in dataextensions

### Testing Steps
- [x] (optional) test with reed searchable files, confirm they can be published
  - [x] (optional) extend the `Image` class with its own index query (using `updateIndexQuery`), confirm this works as expected
- [x] mess up an index query, add `?debug` to the search index task, confirm your query shows with the error

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
