### PR TITLE
fix: delete index entry when document is not found

### DIFF
--- a/src/SearchableExtension.php
+++ b/src/SearchableExtension.php
@@ -332,7 +332,10 @@ class SearchableExtension extends DataExtension
   public function updateIndex()
   {
     $document = $this->getIndexDocument();
-    if (!$document) return;
+    if (!$document) {
+      $this->deleteIndex();
+      return;
+    }
     $id = $this->getSearchableID();
     $index = TNTSearchHelper::Instance()->getTNTSearchIndex();
     $index->update($id, $document);
@@ -416,8 +419,6 @@ class SearchableExtension extends DataExtension
    **/
   public function onAfterDelete()
   {
-      $this->owner->deleteIndex();
+    $this->owner->deleteIndex();
   }
-
 }
-


### PR DESCRIPTION
### Summary
> fix: delete index entry when document is not found

### Testing Steps
- [ ] Test with purple martin: https://github.com/werkbot/purple-martin-conservation-association/pull/163
- [ ] Confirm this fixes the issue with a product that should be excluded from the index

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
